### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,7 @@
 ---
 name: Go
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/peczenyj/pointer/security/code-scanning/5](https://github.com/peczenyj/pointer/security/code-scanning/5)

In general, the fix is to define an explicit `permissions` block that restricts the `GITHUB_TOKEN` to the least privileges needed. Since this workflow only checks out code, runs Go tests, and uploads coverage to Codecov using a separate secret, it only needs read access to repository contents.

The best fix here is to add a top‑level `permissions` block in `.github/workflows/go.yml`, just under the `name: Go` line (before `on:`). This block should set `contents: read`, which is equivalent to the minimal read‑only default for repository contents and is sufficient for `actions/checkout@v4`. No other scopes (like `pull-requests` or `issues`) are required by the shown steps. This change does not modify any existing steps or behavior; it only constrains the implicit GitHub token permissions.

Concretely:
- Edit `.github/workflows/go.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between line 2 (`name: Go`) and line 3 (`on:`).
- No additional imports, methods, or definitions are needed, as this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
